### PR TITLE
Added Bit-Manipulation Support

### DIFF
--- a/rtl/cv32e40p_core.sv
+++ b/rtl/cv32e40p_core.sv
@@ -37,7 +37,8 @@ module cv32e40p_core
     parameter FPU_ADDMUL_LAT = 0,  // Floating-Point ADDition/MULtiplication lane pipeline registers number
     parameter FPU_OTHERS_LAT = 0,  // Floating-Point COMParison/CONVersion lanes pipeline registers number
     parameter ZFINX = 0,  // Float-in-General Purpose registers
-    parameter NUM_MHPMCOUNTERS = 1
+    parameter NUM_MHPMCOUNTERS = 1,
+    parameter ZBITMANIP = 0  // To Enable Bitmanip support
 ) (
     // Clock and Reset
     input logic clk_i,
@@ -523,7 +524,8 @@ module cv32e40p_core
       .APU_WOP_CPU     (APU_WOP_CPU),
       .APU_NDSFLAGS_CPU(APU_NDSFLAGS_CPU),
       .APU_NUSFLAGS_CPU(APU_NUSFLAGS_CPU),
-      .DEBUG_TRIGGER_EN(DEBUG_TRIGGER_EN)
+      .DEBUG_TRIGGER_EN(DEBUG_TRIGGER_EN),
+      .ZBITMANIP       (ZBITMANIP)
   ) id_stage_i (
       .clk          (clk),  // Gated clock
       .clk_ungated_i(clk_i),  // Ungated clock
@@ -744,7 +746,8 @@ module cv32e40p_core
       .APU_NARGS_CPU   (APU_NARGS_CPU),
       .APU_WOP_CPU     (APU_WOP_CPU),
       .APU_NDSFLAGS_CPU(APU_NDSFLAGS_CPU),
-      .APU_NUSFLAGS_CPU(APU_NUSFLAGS_CPU)
+      .APU_NUSFLAGS_CPU(APU_NUSFLAGS_CPU),
+      .ZBITMANIP       (ZBITMANIP)
   ) ex_stage_i (
       // Global signals: Clock and active low asynchronous reset
       .clk  (clk),

--- a/rtl/cv32e40p_ex_stage.sv
+++ b/rtl/cv32e40p_ex_stage.sv
@@ -37,7 +37,8 @@ module cv32e40p_ex_stage
     parameter APU_NARGS_CPU    = 3,
     parameter APU_WOP_CPU      = 6,
     parameter APU_NDSFLAGS_CPU = 15,
-    parameter APU_NUSFLAGS_CPU = 5
+    parameter APU_NUSFLAGS_CPU = 5,
+    parameter ZBITMANIP        = 0
 ) (
     input logic clk,
     input logic rst_n,
@@ -249,7 +250,9 @@ module cv32e40p_ex_stage
   //                        //
   ////////////////////////////
 
-  cv32e40p_alu alu_i (
+  cv32e40p_alu #(
+      .ZBITMANIP(ZBITMANIP)
+  ) alu_i (
       .clk        (clk),
       .rst_n      (rst_n),
       .enable_i   (alu_en_i),

--- a/rtl/cv32e40p_id_stage.sv
+++ b/rtl/cv32e40p_id_stage.sv
@@ -47,7 +47,8 @@ module cv32e40p_id_stage
     parameter APU_WOP_CPU = 6,
     parameter APU_NDSFLAGS_CPU = 15,
     parameter APU_NUSFLAGS_CPU = 5,
-    parameter DEBUG_TRIGGER_EN = 1
+    parameter DEBUG_TRIGGER_EN = 1,
+    parameter ZBITMANIP = 0  // To Enable Bitmanip support
 ) (
     input logic clk,  // Gated clock
     input logic clk_ungated_i,  // Ungated clock
@@ -978,7 +979,8 @@ module cv32e40p_id_stage
       .PULP_SECURE     (PULP_SECURE),
       .USE_PMP         (USE_PMP),
       .APU_WOP_CPU     (APU_WOP_CPU),
-      .DEBUG_TRIGGER_EN(DEBUG_TRIGGER_EN)
+      .DEBUG_TRIGGER_EN(DEBUG_TRIGGER_EN),
+      .ZBITMANIP       (ZBITMANIP)
   ) decoder_i (
       // controller related signals
       .deassert_we_i(deassert_we),

--- a/rtl/cv32e40p_top.sv
+++ b/rtl/cv32e40p_top.sv
@@ -18,7 +18,8 @@ module cv32e40p_top #(
     parameter FPU_ADDMUL_LAT = 0,  // Floating-Point ADDition/MULtiplication computing lane pipeline registers number
     parameter FPU_OTHERS_LAT = 0,  // Floating-Point COMParison/CONVersion computing lanes pipeline registers number
     parameter ZFINX = 0,  // Float-in-General Purpose registers
-    parameter NUM_MHPMCOUNTERS = 1
+    parameter NUM_MHPMCOUNTERS = 1,
+    parameter ZBITMANIP = 0  // To Enable Bitmanip support 
 ) (
     // Clock and Reset
     input logic clk_i,
@@ -90,7 +91,8 @@ module cv32e40p_top #(
       .FPU_ADDMUL_LAT  (FPU_ADDMUL_LAT),
       .FPU_OTHERS_LAT  (FPU_OTHERS_LAT),
       .ZFINX           (ZFINX),
-      .NUM_MHPMCOUNTERS(NUM_MHPMCOUNTERS)
+      .NUM_MHPMCOUNTERS(NUM_MHPMCOUNTERS),
+      .ZBITMANIP       (ZBITMANIP)
   ) core_i (
       .clk_i (clk_i),
       .rst_ni(rst_ni),

--- a/rtl/include/cv32e40p_pkg.sv
+++ b/rtl/include/cv32e40p_pkg.sv
@@ -156,7 +156,47 @@ package cv32e40p_pkg;
     ALU_SHUF  = 7'b0111010,
     ALU_SHUF2 = 7'b0111011,
     ALU_PCKLO = 7'b0111000,
-    ALU_PCKHI = 7'b0111001
+    ALU_PCKHI = 7'b0111001,
+
+    //Zba: Address generation Instructions
+    ALU_B_SH1ADD = 7'b0001111,
+    ALU_B_SH2ADD = 7'b0001110,
+    ALU_B_SH3ADD = 7'b1110010,
+
+    //Zbb: Basic Bit-Manipulation
+    ALU_B_ANDN  = 7'b1100010,
+    ALU_B_MAX   = 7'b0111100,
+    ALU_B_MIN   = 7'b0111101,
+    ALU_B_ROL   = 7'b1010110,
+    ALU_B_ROR   = 7'b1011110,
+    ALU_B_XNOR  = 7'b1011100,
+    ALU_B_ORN   = 7'b1010100,
+    ALU_B_MAXU  = 7'b1100000,
+    ALU_B_MINU  = 7'b1110110,
+    ALU_B_RORI  = 7'b1110111,
+    ALU_B_ORCB  = 7'b1100001,
+    ALU_B_REV8  = 7'b1100011,
+    ALU_B_SEXTB = 7'b1100100,
+    ALU_B_SEXTH = 7'b1100101,
+    ALU_B_ZEXTH = 7'b1100110,
+    ALU_B_CPOP  = 7'b1100111,
+    ALU_B_CTZ   = 7'b1101001,
+    ALU_B_CLZ   = 7'b1111110,
+
+    //Zbc: Carry-less Multiplication
+    ALU_B_CLMUL  = 7'b1101010,
+    ALU_B_CLMULH = 7'b1101011,
+    ALU_B_CLMULR = 7'b1101100,
+
+    //Zbs: Single-bit Instructions
+    ALU_B_BCLR  = 7'b1101101,
+    ALU_B_BCLRI = 7'b1101110,
+    ALU_B_BEXT  = 7'b1101111,
+    ALU_B_BEXTI = 7'b1110000,
+    ALU_B_BINV  = 7'b1110001,
+    ALU_B_BINVI = 7'b1110011,
+    ALU_B_BSET  = 7'b1110100,
+    ALU_B_BSETI = 7'b1110101
 
   } alu_opcode_e;
 


### PR DESCRIPTION
### Introduction
This PR adds support for the zba, zbb, zbc and zbs extensions in CV32E40P core. This support will be enabled by changing `parameter ZBITMANIP = 1` in **cv32e40p_pkg.sv** file and disabled by changing  `parameter ZBITMANIP = 0`

### Implementation
Added the support for all the ratified bitmanip extensions as defined under this [bitmanip-spec](https://github.com/riscv/riscv-bitmanip/releases/download/1.0.0/bitmanip-1.0.0-38-g865e7a7.pdf)

- Zba: Address generation Instructions
- Zbb: Basic Bit-Manipulation
- Zbc: Carry-less Multiplication
- Zbs: Single-bit Instructions

### Verification
All the implemented instructions are passing riscv-arch tests for B type instructions. I have implemented the CV32E40P core as a DUT and SAIL as a reference model within the RISCOF framework, the successful execution of riscv-arch tests on both the CV32E40P core and the SAIL reference model and the comparison of their signatures provided the desired test results.  

![web](https://github.com/10x-Engineers/cv32e40p/assets/124154913/4b93fa7d-cc57-4371-beb7-69666c0853eb)
![ter](https://github.com/10x-Engineers/cv32e40p/assets/124154913/dad753a8-1f23-4c3f-a304-aed3eae8573d)


   
